### PR TITLE
Update CMake to be compatible with Moni_align git_submodule branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 ################################################################################
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING 
+      "Choose the type of build, options are: Release|Debug|RelWithDebInfo (for distros)." FORCE)
 endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Install directory: ${CMAKE_INSTALL_PREFIX}")
@@ -17,13 +18,13 @@ message(STATUS "Install directory: ${CMAKE_INSTALL_PREFIX}")
 # Version number
 execute_process(
         COMMAND git rev-parse --abbrev-ref HEAD
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
         OUTPUT_VARIABLE GIT_BRANCH
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 execute_process(
         COMMAND git log -1 --format=%h
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
         OUTPUT_VARIABLE GIT_COMMIT_HASH
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -32,10 +33,10 @@ message(STATUS "Git commit hash: ${GIT_COMMIT_HASH}")
 
 message(STATUS "Generating version.hpp")
 configure_file(
-        ${CMAKE_SOURCE_DIR}/include/version.hpp.in
-        ${CMAKE_BINARY_DIR}/generated/version.hpp)
+        ${CMAKE_CURRENT_LIST_DIR}/include/version.hpp.in
+        ${CMAKE_CURRENT_BINARY_DIR}/generated/version.hpp)
 
-include_directories(${CMAKE_BINARY_DIR}/generated)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 ################################################################################
 # Compiler and linker flags
@@ -105,7 +106,7 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/thirdparty)
 include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_BINARY_DIR}/generated)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 file(GLOB SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
 file(GLOB MALLOC_COUNT_SOURCES ${CMAKE_SOURCE_DIR}/thirdparty/malloc_count/*.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,12 +110,11 @@ include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 file(GLOB SOURCES ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
-file(GLOB MALLOC_COUNT_SOURCES ${CMAKE_CURRENT_LIST_DIR}/thirdparty/malloc_count/*.c)
 file(GLOB MURMUR_SOURCES ${CMAKE_CURRENT_LIST_DIR}/thirdparty/murmur/*.cpp)
 
 # 32 and 64 bits parse
-add_library(pfp ${SOURCES} ${MALLOC_COUNT_SOURCES} ${MURMUR_SOURCES})
-add_library(pfp64 ${SOURCES} ${MALLOC_COUNT_SOURCES} ${MURMUR_SOURCES})
+add_library(pfp ${SOURCES} ${MURMUR_SOURCES})
+add_library(pfp64 ${SOURCES} ${MURMUR_SOURCES})
 target_link_libraries(pfp lvsam)
 target_link_libraries(pfp64 lvsam)
 target_compile_options(pfp64 PRIVATE "-DPFP_LONG_TYPE=ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,11 @@ add_executable(vcf_to_fa vcf_to_fa.cpp)
 target_link_libraries(vcf_to_fa pfp ${VCF_LIB_DEPS})
 
 # Unparse
-add_executable(unparse unparse.cpp)
-target_link_libraries(unparse pfp ${VCF_LIB_DEPS})
-add_executable(unparse64 unparse.cpp)
-target_compile_options(unparse64 PRIVATE "-DPFP_LONG_TYPE=ON")
-target_link_libraries(unparse64 pfp64 ${VCF_LIB_DEPS})
+add_executable(pfp++_unparse unparse.cpp)
+target_link_libraries(pfp++_unparse pfp ${VCF_LIB_DEPS})
+add_executable(pfp++64_unparse unparse.cpp)
+target_compile_options(pfp++64_unparse PRIVATE "-DPFP_LONG_TYPE=ON")
+target_link_libraries(pfp++64_unparse pfp64 ${VCF_LIB_DEPS})
 
 # Integrity Check
 add_executable(check check_integrity.cpp)
@@ -175,4 +175,4 @@ add_executable(check64 check_integrity.cpp)
 target_compile_options(check64 PRIVATE "-DPFP_LONG_TYPE=ON")
 target_link_libraries(check64 pfp64 ${VCF_LIB_DEPS})
 
-install(TARGETS pfp++ pfp++64 AuPair AuPair64 mpfp++ mpfp++64 unparse unparse64 check check64 TYPE RUNTIME)
+install(TARGETS pfp++ pfp++64 AuPair AuPair64 mpfp++ mpfp++64 pfp++_unparse pfp++64_unparse check check64 TYPE RUNTIME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 
 # HTS
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+find_package(ZLIB REQUIRED)
 find_package(HTSlib REQUIRED)
 if(HTSlib_FOUND)
     include_directories(${HTSlib_INCLUDE_DIRS})
@@ -104,13 +105,13 @@ endif()
 ################################################################################
 # Lib
 
-include_directories(${CMAKE_SOURCE_DIR}/thirdparty)
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/thirdparty)
+include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
 
-file(GLOB SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
-file(GLOB MALLOC_COUNT_SOURCES ${CMAKE_SOURCE_DIR}/thirdparty/malloc_count/*.c)
-file(GLOB MURMUR_SOURCES ${CMAKE_SOURCE_DIR}/thirdparty/murmur/*.cpp)
+file(GLOB SOURCES ${CMAKE_CURRENT_LIST_DIR}/src/*.cpp)
+file(GLOB MALLOC_COUNT_SOURCES ${CMAKE_CURRENT_LIST_DIR}/thirdparty/malloc_count/*.c)
+file(GLOB MURMUR_SOURCES ${CMAKE_CURRENT_LIST_DIR}/thirdparty/murmur/*.cpp)
 
 # 32 and 64 bits parse
 add_library(pfp ${SOURCES} ${MALLOC_COUNT_SOURCES} ${MURMUR_SOURCES})
@@ -119,7 +120,7 @@ target_link_libraries(pfp lvsam)
 target_link_libraries(pfp64 lvsam)
 target_compile_options(pfp64 PRIVATE "-DPFP_LONG_TYPE=ON")
 
-set(VCF_LIB_DEPS ${HTSlib_LIBRARIES} dl pthread lvsam)# ssl crypto)
+set(VCF_LIB_DEPS ${HTSlib_LIBRARIES} ${ZLIB_LIBRARIES} dl pthread lvsam)# ssl crypto)
 
 ################################################################################
 # Tests

--- a/include/pfp_algo.hpp
+++ b/include/pfp_algo.hpp
@@ -253,6 +253,32 @@ private:
     std::string out_file_name;
     std::string in_file_path;
     std::vector<std::string> sequences_processed;
+
+    std::ofstream out_lift;
+    std::string out_lift_prefix;
+    std::string out_lift_name;
+    std::string tmp_out_lift_name;
+
+    std::ofstream out_len;
+    std::string out_len_prefix;
+    std::string out_len_name;
+    std::string tmp_out_len_name;
+
+    std::string reference; // TODO: Replace it with as many parses as references.
+    std::vector<std::string> references;
+    std::vector<std::string> references_name;
+    std::unordered_map<std::string, std::size_t> references_id;
+    
+    std::vector<std::vector<Variation>> variations;
+    std::vector<Contig> contigs;
+    std::vector<Sample> samples;
+    std::unordered_map<std::string, std::size_t> samples_id;
+    
+    std::size_t max_samples = 0;
+    std::set<std::string> input_samples;
+    std::vector<std::size_t> populated_samples;
+
+    std::vector<std::size_t> ref_sum_lengths;
     
     Params params;
     Statistics statistics;
@@ -267,6 +293,8 @@ private:
 public:
     
     void init(const Params& params, const std::string& prefix);
+
+    void init_ref(const std::string& ref_path, const size_t w, bool last);
     
     ParserFasta(const Params& params, const std::string& file_path, const std::string& out_prefix)
     {

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -31,7 +31,6 @@
 #include <mio/mmap.hpp>
 #include <omp.h>
 
-#include <malloc_count/malloc_count.h>
 #include <murmur/MurmurHash3.h>
 
 #include <indexed_pq/indexMaxPQ.h>


### PR DESCRIPTION
Main things:

1. Changed instances of CMAKE_SOURCE_DIR -> CMAKE_CURRENT_LIST_DIR
2. Changed instances of CMAKE_BINARY_DIR -> CMAKE_CURRENT_BINARY_DIR
3. Add zlib library to targets
4. Changed the target name of unparse and unparse64 to pfp++_unparse and pfp++64_unparse to avoid target naming conflicts with BigBWT. 
5. Add the ability to write dummy LevioSAM lifting files for FASTA such that we can use FASTA input for moni-align.
